### PR TITLE
fixed garbage output for 5642 on Raspberry Pi

### DIFF
--- a/ArduCAM/examples/RaspberryPi/arducam_ov5642_capture.cpp
+++ b/ArduCAM/examples/RaspberryPi/arducam_ov5642_capture.cpp
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
       while ( length-- )
 		  {
 		    temp_last = temp;
-		    temp =  myCAM.transfer(0x00);
+		    temp =  myCAM.read_fifo();
 		    //Read JPEG data from FIFO
 		    if ( (temp == 0xD9) && (temp_last == 0xFF) ) //If find the end ,break while,
 		    {


### PR DESCRIPTION
transfer(0x00) writes 'U' repetitively, producing garbage output. read_fifo() reads from the camera.